### PR TITLE
ci: add automerge qa gate

### DIFF
--- a/.github/scripts/qa_gate_workflow_test.py
+++ b/.github/scripts/qa_gate_workflow_test.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+import re
+
+
+GITHUB_DIR = Path(__file__).resolve().parents[1]
+WORKFLOW = GITHUB_DIR / "workflows" / "qa-gate.yml"
+
+
+def _workflow_text() -> str:
+    assert WORKFLOW.exists(), "qa-gate.yml must define the automerge safety gate"
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_workflow_triggers_on_pull_request_and_manual_dispatch() -> None:
+    workflow = _workflow_text()
+
+    assert re.search(r"(?m)^\s+pull_request:\s*$", workflow)
+    assert re.search(r"(?m)^\s+workflow_dispatch:\s*$", workflow)
+
+
+def test_workflow_runs_python_312_and_node_backed_test_suite() -> None:
+    workflow = _workflow_text()
+
+    assert "python-version: \"3.12\"" in workflow
+    assert "actions/setup-node@" in workflow
+    assert "python -m venv .venv" in workflow
+    assert ".venv/bin/python -m pip install" in workflow
+    assert re.search(
+        r"\.venv/bin/python -m pytest \.github/scripts/qa_gate_workflow_test\.py tests\b",
+        workflow,
+    )
+    assert "bash tests/test_wrapper.sh" in workflow
+
+
+def test_workflow_publishes_fail_closed_automerge_gate_context() -> None:
+    workflow = _workflow_text()
+
+    assert re.search(r"(?m)^\s+automerge-gate:\s*$", workflow)
+    assert re.search(r"(?m)^\s+name:\s+automerge-gate\s*$", workflow)
+    assert re.search(r"(?m)^\s+if:\s+\$\{\{\s*always\(\)\s*\}\}\s*$", workflow)
+    assert "needs.tests.result" in workflow

--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -1,0 +1,58 @@
+name: QA Gate
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: qa-gate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Install dependencies
+        run: |
+          python -m venv .venv
+          .venv/bin/python -m pip install --upgrade pip
+          .venv/bin/python -m pip install -r requirements.txt pytest
+
+      - name: Run pytest
+        run: .venv/bin/python -m pytest .github/scripts/qa_gate_workflow_test.py tests
+
+      - name: Run wrapper smoke
+        run: bash tests/test_wrapper.sh
+
+  automerge-gate:
+    name: automerge-gate
+    runs-on: ubuntu-latest
+    needs: [tests]
+    if: ${{ always() }}
+    steps:
+      - name: Require tests to pass
+        env:
+          TESTS_RESULT: ${{ needs.tests.result }}
+        run: |
+          if [ "$TESTS_RESULT" != "success" ]; then
+            echo "tests result: $TESTS_RESULT"
+            exit 1
+          fi

--- a/tests/test_wrapper.sh
+++ b/tests/test_wrapper.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-export LIFE_VENV="${LIFE_VENV:-$HOME/.claude/skills/life/.venv}"
+export LIFE_VENV="${LIFE_VENV:-$REPO/.venv}"
 
 if [ ! -x "$LIFE_VENV/bin/python" ]; then
   echo "missing test venv python at $LIFE_VENV/bin/python" >&2


### PR DESCRIPTION
## Summary
- add a pull-request QA Gate workflow with a fail-closed automerge-gate job
- add a workflow contract test for the required automerge safety context
- make wrapper smoke tests use the repo-local venv by default

## Tests
- python -m pytest .github/scripts/qa_gate_workflow_test.py tests
- bash tests/test_wrapper.sh