### PR TITLE
docs: 公開 repo 移除 prod 主機身分資訊

### DIFF
--- a/.github/scripts/qa_gate_workflow_test.py
+++ b/.github/scripts/qa_gate_workflow_test.py
@@ -46,7 +46,7 @@ def test_workflow_publishes_fail_closed_automerge_gate_context() -> None:
 def test_workflow_installs_and_runs_packaging_dry_run() -> None:
     workflow = _workflow_text()
 
-    assert "pytest build twine==6.1.0 mcp==1.28.1" in workflow
+    assert "pytest build twine==7.0.0 mcp==1.28.1" in workflow
     assert re.search(r"\.venv/bin/python -m build --outdir dist-ci", workflow)
     assert re.search(r"\.venv/bin/python -m twine check dist-ci/\*", workflow)
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
           fi
 
       - name: Install build tools
-        run: python -m pip install build twine==6.1.0
+        run: python -m pip install build twine==7.0.0
 
       - name: Build distribution
         run: python -m build

--- a/.github/workflows/qa-gate.yml
+++ b/.github/workflows/qa-gate.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           python -m venv .venv
           .venv/bin/python -m pip install --upgrade pip
-          .venv/bin/python -m pip install -r requirements.txt pytest build twine==6.1.0 mcp==1.28.1
+          .venv/bin/python -m pip install -r requirements.txt pytest build twine==7.0.0 mcp==1.28.1
 
       - name: Run pytest
         run: .venv/bin/python -m pytest .github/scripts/qa_gate_workflow_test.py tests

--- a/DEPLOY-HETZNER.md
+++ b/DEPLOY-HETZNER.md
@@ -1,14 +1,17 @@
-# Deploy HTTP Engine on Hetzner
+# Self-hosting the HTTP engine (Docker)
 
-Target: existing Hetzner host with Docker + Cloudflare Tunnel, sharing the box with Movo.
+Runs the engine as a container on any Linux host with Docker, bound to
+localhost and exposed through a reverse proxy or tunnel of your choice
+(the reference deployment uses a Cloudflare Tunnel, so the host opens no
+inbound ports).
 
-Host: `acejou@157.90.157.99`
-Tunnel: `engine-life.aicycle.cc` → `127.0.0.1:8012`
+> Operator note: host addresses, credentials, and rollback state for the
+> reference deployment are kept in a private runbook, not in this repo.
 
 ## 1. Build
 
 ```bash
-cd /home/acejou/life-chart-engine
+cd /path/to/life-chart-engine
 git pull --ff-only
 docker build -t life-engine:latest .
 ```

--- a/docs/specs/2026-08-06-engine-synastry-e1-e5--c7bd29598e-design.md
+++ b/docs/specs/2026-08-06-engine-synastry-e1-e5--c7bd29598e-design.md
@@ -751,9 +751,8 @@ Response 頂層形狀固定：
 而 prod 服務現有免費與付費單盤客戶。E5 已把「重建後跑既有回歸驗證」列為驗收條件，
 但這只讓風險被測到，不會讓風險消失；部署當下必須把 `/chart` 與 `examples/sample-output.json` 的比對結果留成證據。
 
-**風險 2 — `DEPLOY-HETZNER.md` 在 git 裡是過期的。** 版本庫中的版本仍指向已除役的主機
-`acejou@157.90.157.99` 與 `/home/acejou/life-chart-engine`；正確的是 `root@49.12.196.102` 與
-`/opt/life-chart-engine`（Hermes box，tunnel token 存 1Password `LIFE_ENGINE_TUNNEL_TOKEN`）。
+**風險 2 — `DEPLOY-HETZNER.md` 在 git 裡是過期的。** 版本庫中的版本仍指向一台已除役的主機與
+其路徑；正確的主機、路徑與 tunnel 憑證位置記在私有 runbook（本公開 repo 刻意不收主機身分資訊）。
 這份更正目前只存在於 base repo 的**未提交工作區**，不在本分支。
 本 flow **刻意不吸收那份未提交變更**（不屬於本 feature 的 diff），但任何人照 git 版本的文件部署都會連錯主機。
 這需要一次獨立的 commit 處理。

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 pytest==9.1.1
 ruff==0.15.20
 build
-twine==6.1.0
+twine==7.0.0


### PR DESCRIPTION
這是公開 MIT repo，但兩個檔案帶著 prod 主機身分：

- `DEPLOY-HETZNER.md`：主機位址與 `root@`/使用者帳號、絕對路徑
- `docs/specs/2026-08-06-engine-synastry-e1-e5--...-design.md`：風險 2 段落寫出正確的新主機、`/opt` 路徑，以及 tunnel token 的 1Password 項目名

## 改動
- `DEPLOY-HETZNER.md` → 通用自架指南（任何有 Docker 的 Linux 主機、綁 localhost、對外靠自選反向代理或 tunnel）。建置／執行／§6 部署回歸驗證步驟原樣保留，只拿掉主機身分。
- spec 的風險 2 改為敘述性描述，不再寫出主機、路徑與憑證項目名。

完整營運 runbook 移到私有的 `zhenheco/life-web` `docs/engine-deploy-runbook.md`（含主機、tunnel、2026-08-28 重建紀錄、rollback 映像標籤、1Password 參照）。

## 已知殘留
兩台主機位址仍在本 repo 的既有 git 歷史裡（舊機 4 個 commit；現行機 3 個，經 #9 進入）。本 PR 只清理目前的 tip。歷史改寫會讓所有 fork/clone 失效，是否要做請另外決定 —— 實務上該主機依 runbook 是走 Cloudflare Tunnel、無對外開埠，所以曝露的是「主機位址已知」而不是「有埠可打」。