### PR TITLE
fix: /chart 錯誤契約改用六 token envelope（F-2 洩漏、F-3 不一致）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -397,7 +397,7 @@ with fixed, mutually exclusive key sets:
 | situation | status | `error` | `field` |
 |---|---|---|---|
 | body is not JSON (invalid UTF-8, or JSON nested too deep to parse — a parser `RecursionError`) | `400` | `invalid_json` | `null` |
-| body not an object | `400` | `invalid_input` | `person_a` |
+| body not an object | `400` | `invalid_input` | `null` (`/chart`) / `person_a` (`/synastry`) |
 | `person_a` / `person_b` missing or not an object | `400` | `invalid_input` | `person_a` / `person_b` |
 | per-person field missing/malformed/out-of-range/out-of-window | `400` | `invalid_input` | prefixed field (`person_a.date`, `person_b.time`, …); first error only, `person_a` before `person_b` |
 | `X-Engine-Key` missing or wrong | `401` | `unauthorized` | `null` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -372,10 +372,18 @@ surface (same shared validator); only the carrier differs:
 
 | failure class | CLI | HTTP `/chart` | MCP `compute_chart` |
 |---|---|---|---|
-| validation error (missing/malformed/out-of-range/out-of-window input) | exit `2`, empty stdout, usage on stderr | `400` + `detail` naming the field | `isError: true` + field-named message |
-| runtime error (Node sidecar failure, high-latitude Placidus, timeout) | exit `1` (`--json`: one `{"ok": false}` envelope; Markdown: message on stderr, empty stdout) | `500` + `{"ok": false, ...}` envelope | `isError: true` + message |
+| validation error (missing/malformed/out-of-range/out-of-window input) | exit `2`, empty stdout, usage on stderr | `400` six-token envelope (see below) | `isError: true` + field-named message |
+| runtime error (Node sidecar failure, high-latitude Placidus, timeout) | exit `1` (`--json`: one `{"ok": false}` envelope; Markdown: message on stderr, empty stdout) | `422` / `500` six-token envelope (see below) | `isError: true` + message |
 
-### HTTP `POST /synastry` error contract (six fixed tokens)
+### HTTP error contract (six fixed tokens) — `/chart` and `/synastry`
+
+Both `/chart` and `/synastry` use the same six tokens, decision order, and two
+body shapes. The only differences are:
+
+- `internal_error` fixed message: `"/chart"` → `"chart computation failed"`,
+  `"/synastry"` → `"synastry computation failed"`.
+- `person_a`/`person_b`-related `invalid_input` rows (table below) apply only
+  to `/synastry`; `/chart`'s body-not-object is `field=null`.
 
 `error` is a fixed machine-parsable token; consumers should read only it.
 There are exactly two body shapes, chosen by token (never by status code),
@@ -399,8 +407,9 @@ with fixed, mutually exclusive key sets:
 
 Fixed messages: `computation_unsupported` → `"chart cannot be computed for the
 given coordinates"`; `not_configured` → `"ENGINE_API_KEY not configured"`;
-`internal_error` → `"synastry computation failed"` (the real exception goes to
-Sentry, never into the body).
+`internal_error` → `"chart computation failed"` (`/chart`) or
+`"synastry computation failed"` (`/synastry`) — the real exception goes to
+Sentry, never into the body.
 
 **Decision order is fixed:** `not_configured` → `unauthorized` → `invalid_json`
 → `invalid_input` → `computation_unsupported` → `internal_error`. When several

--- a/server.py
+++ b/server.py
@@ -42,6 +42,10 @@ async def chart(request: Request, x_engine_key: str | None = Header(default=None
         return build_json(_engine_input(body))
     except HTTPException:
         raise  # 400s from _engine_input pass through unchanged
+    except ComputationUnsupportedError:
+        return _message_error(
+            422, ERROR_COMPUTATION_UNSUPPORTED, MESSAGE_COMPUTATION_UNSUPPORTED
+        )
     except Exception as exc:  # build_json / ephemeris edge input
         capture_exception(exc)
         return JSONResponse(

--- a/server.py
+++ b/server.py
@@ -1,9 +1,8 @@
 import hmac
 import os
-from json import JSONDecodeError
 from typing import Any
 
-from fastapi import FastAPI, Header, HTTPException, Request
+from fastapi import FastAPI, Header, Request
 from fastapi.responses import JSONResponse
 
 from scripts.chart_engine import build_json
@@ -181,15 +180,6 @@ def _auth_failure(x_engine_key: str | None) -> str | None:
     return None
 
 
-def _require_key(x_engine_key: str | None) -> None:
-    """/chart auth — keeps the historical ``{"detail": ...}`` bodies unchanged."""
-    failure = _auth_failure(x_engine_key)
-    if failure == "not_configured":
-        raise HTTPException(status_code=503, detail=MESSAGE_NOT_CONFIGURED)
-    if failure == "unauthorized":
-        raise HTTPException(status_code=401, detail="unauthorized")
-
-
 def _input_error(status: int, error: str, field: Any, detail: str) -> JSONResponse:
     # Input-error shape (invalid_json / invalid_input / unauthorized):
     # exactly {ok, error, field, detail}.
@@ -205,16 +195,3 @@ def _message_error(status: int, error: str, message: str) -> JSONResponse:
     return JSONResponse(
         status_code=status, content={"ok": False, "error": error, "message": message}
     )
-
-
-def _engine_input(body: Any) -> dict[str, Any]:
-    if not isinstance(body, dict):
-        raise HTTPException(status_code=400, detail="body must be a JSON object")
-
-    # Single validation source shared with the CLI (and MCP): scripts/validation.py.
-    # Out-of-range / non-finite / out-of-window rejection is deliberate 400 hardening
-    # over the historical float()-coercion behaviour — see AGENTS.md §3/§5.
-    try:
-        return validate_input(body)
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/server.py
+++ b/server.py
@@ -39,15 +39,28 @@ async def chart(request: Request, x_engine_key: str | None = Header(default=None
         body = await request.json()
     except (ValueError, RecursionError):
         return _input_error(400, "invalid_json", None, "body must be valid JSON")
+
+    if not isinstance(body, dict):
+        return _input_error(400, "invalid_input", None, "body must be a JSON object")
+
     try:
-        return build_json(_engine_input(body))
-    except HTTPException:
-        raise  # 400s from _engine_input pass through unchanged
+        inp = validate_input(body)
+    except ValueError as exc:
+        field, separator, detail = str(exc).partition(":")
+        if separator:
+            return _input_error(400, "invalid_input", field, detail.strip())
+        return _input_error(400, "invalid_input", None, str(exc))
+    except Exception as exc:
+        capture_exception(exc)
+        return _message_error(500, ERROR_INTERNAL, MESSAGE_CHART_INTERNAL)
+
+    try:
+        return build_json(inp)
     except ComputationUnsupportedError:
         return _message_error(
             422, ERROR_COMPUTATION_UNSUPPORTED, MESSAGE_COMPUTATION_UNSUPPORTED
         )
-    except Exception as exc:  # build_json / ephemeris edge input
+    except Exception as exc:
         capture_exception(exc)
         return _message_error(500, ERROR_INTERNAL, MESSAGE_CHART_INTERNAL)
 

--- a/server.py
+++ b/server.py
@@ -36,8 +36,8 @@ async def chart(request: Request, x_engine_key: str | None = Header(default=None
     _require_key(x_engine_key)
     try:
         body = await request.json()
-    except JSONDecodeError as exc:
-        raise HTTPException(status_code=400, detail="invalid JSON body") from exc
+    except (ValueError, RecursionError):
+        return _input_error(400, "invalid_json", None, "body must be valid JSON")
     try:
         return build_json(_engine_input(body))
     except HTTPException:

--- a/server.py
+++ b/server.py
@@ -24,6 +24,7 @@ init_sentry()
 app = FastAPI(title="life-chart-engine")
 
 MESSAGE_NOT_CONFIGURED = "ENGINE_API_KEY not configured"
+MESSAGE_CHART_INTERNAL = "chart computation failed"
 
 
 @app.get("/health")
@@ -48,10 +49,7 @@ async def chart(request: Request, x_engine_key: str | None = Header(default=None
         )
     except Exception as exc:  # build_json / ephemeris edge input
         capture_exception(exc)
-        return JSONResponse(
-            status_code=500,
-            content={"ok": False, "error": str(exc), "schema_version": "1.2"},
-        )
+        return _message_error(500, ERROR_INTERNAL, MESSAGE_CHART_INTERNAL)
 
 
 @app.post("/synastry")

--- a/server.py
+++ b/server.py
@@ -34,7 +34,12 @@ def health():
 
 @app.post("/chart")
 async def chart(request: Request, x_engine_key: str | None = Header(default=None)):
-    _require_key(x_engine_key)
+    failure = _auth_failure(x_engine_key)
+    if failure == "not_configured":
+        return _message_error(503, "not_configured", MESSAGE_NOT_CONFIGURED)
+    if failure == "unauthorized":
+        return _input_error(401, "unauthorized", None, "missing or incorrect X-Engine-Key")
+
     try:
         body = await request.json()
     except (ValueError, RecursionError):

--- a/tests/test_node_absence.py
+++ b/tests/test_node_absence.py
@@ -91,7 +91,11 @@ def test_failing_or_hanging_node_converges_to_the_same_loud_path(tmp_path, fake_
     assert "Node.js >= 18" in payload["error"]
 
 
-def test_http_chart_returns_500_with_node_guidance(monkeypatch):
+def test_http_chart_500_withholds_sidecar_message(monkeypatch):
+    """HTTP is a public surface: the sidecar's stderr (container paths, Node
+    output) must never reach the caller. The operator guidance still reaches
+    the CLI (test above), the container log and Sentry — the HTTP body is a
+    fixed message."""
     def node_is_gone(_inp):
         raise RuntimeError(
             "紫微斗數 sidecar failed: node executable not found on PATH "
@@ -118,6 +122,10 @@ def test_http_chart_returns_500_with_node_guidance(monkeypatch):
     sys.modules.pop("server", None)
 
     assert response.status_code == 500
-    body = response.json()
-    assert body["ok"] is False
-    assert "Node.js >= 18" in body["error"]
+    assert response.json() == {
+        "ok": False,
+        "error": "internal_error",
+        "message": "chart computation failed",
+    }
+    assert "Node.js" not in response.text
+    assert "sidecar" not in response.text

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -412,3 +412,39 @@ def test_non_string_gender_returns_400_not_500(server_client):
     assert response.status_code == 400
     assert "gender" in response.json()["detail"]
     assert calls == []
+
+
+def test_invalid_utf8_body_is_invalid_json(server_client):
+    client, calls = server_client
+
+    response = client.post(
+        "/chart",
+        content=b"\xff\xfe",
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 400
+    payload = response.json()
+    assert payload["ok"] is False
+    assert payload["error"] == "invalid_json"
+    assert payload["field"] is None
+    assert payload["detail"] == "body must be valid JSON"
+    assert set(payload) == {"ok", "error", "field", "detail"}
+    assert calls == []
+
+
+def test_deeply_nested_body_is_invalid_json(server_client):
+    client, calls = server_client
+    body = b"[" * 10000 + b"]" * 10000
+
+    response = client.post(
+        "/chart",
+        content=body,
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 400
+    payload = response.json()
+    assert payload["error"] == "invalid_json"
+    assert payload["field"] is None
+    assert calls == []

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -84,7 +84,9 @@ def test_invalid_ziwei_day_divide_returns_400(server_client):
     response = client.post("/chart", json={**BODY, "ziwei_day_divide": "tomorrow"})
 
     assert response.status_code == 400
-    assert "ziwei_day_divide" in response.json()["detail"]
+    payload = response.json()
+    assert payload["error"] == "invalid_input"
+    assert payload["field"] == "ziwei_day_divide"
     assert calls == []
 
 
@@ -96,7 +98,9 @@ def test_missing_required_field_returns_400(server_client):
     response = client.post("/chart", json=body)
 
     assert response.status_code == 400
-    assert "lon" in response.json()["detail"]
+    payload = response.json()
+    assert payload["error"] == "invalid_input"
+    assert payload["field"] == "lon"
     assert calls == []
 
 
@@ -106,7 +110,9 @@ def test_invalid_gender_returns_400(server_client):
     response = client.post("/chart", json={**BODY, "gender": "other"})
 
     assert response.status_code == 400
-    assert "gender" in response.json()["detail"]
+    payload = response.json()
+    assert payload["error"] == "invalid_input"
+    assert payload["field"] == "gender"
     assert calls == []
 
 
@@ -116,7 +122,9 @@ def test_invalid_target_returns_400(server_client):
     response = client.post("/chart", json={**BODY, "target": "not-a-date"})
 
     assert response.status_code == 400
-    assert "target" in response.json()["detail"]
+    payload = response.json()
+    assert payload["error"] == "invalid_input"
+    assert payload["field"] == "target"
     assert calls == []
 
 
@@ -126,7 +134,9 @@ def test_invalid_time_returns_400(server_client):
     response = client.post("/chart", json={**BODY, "time": "aa:bb"})
 
     assert response.status_code == 400
-    assert "time" in response.json()["detail"]
+    payload = response.json()
+    assert payload["error"] == "invalid_input"
+    assert payload["field"] == "time"
     assert calls == []
 
 
@@ -311,7 +321,9 @@ def test_out_of_range_numeric_values_return_400(server_client, field, value):
     response = client.post("/chart", json={**BODY, field: value})
 
     assert response.status_code == 400
-    assert field in response.json()["detail"]
+    payload = response.json()
+    assert payload["error"] == "invalid_input"
+    assert payload["field"] == field
     assert calls == []
 
 
@@ -329,9 +341,13 @@ def test_nonfinite_values_return_400(server_client, payload_field):
     )
 
     assert string_inf.status_code == 400
-    assert payload_field in string_inf.json()["detail"]
+    payload = string_inf.json()
+    assert payload["error"] == "invalid_input"
+    assert payload["field"] == payload_field
     assert literal_nan.status_code == 400
-    assert payload_field in literal_nan.json()["detail"]
+    payload = literal_nan.json()
+    assert payload["error"] == "invalid_input"
+    assert payload["field"] == payload_field
     assert calls == []
 
 
@@ -350,7 +366,9 @@ def test_out_of_window_years_return_400(server_client, field, value):
     response = client.post("/chart", json={**BODY, field: value})
 
     assert response.status_code == 400
-    assert field in response.json()["detail"]
+    payload = response.json()
+    assert payload["error"] == "invalid_input"
+    assert payload["field"] == field
     assert calls == []
 
 
@@ -388,7 +406,9 @@ def test_non_string_ziwei_day_divide_returns_400_not_500(server_client):
     response = client.post("/chart", json={**BODY, "ziwei_day_divide": ["forward"]})
 
     assert response.status_code == 400
-    assert "ziwei_day_divide" in response.json()["detail"]
+    payload = response.json()
+    assert payload["error"] == "invalid_input"
+    assert payload["field"] == "ziwei_day_divide"
     assert calls == []
 
 
@@ -410,7 +430,9 @@ def test_non_string_gender_returns_400_not_500(server_client):
     response = client.post("/chart", json={**BODY, "gender": ["女"]})
 
     assert response.status_code == 400
-    assert "gender" in response.json()["detail"]
+    payload = response.json()
+    assert payload["error"] == "invalid_input"
+    assert payload["field"] == "gender"
     assert calls == []
 
 
@@ -503,4 +525,23 @@ def test_internal_error_does_not_leak_exception_message(server_client, monkeypat
     assert "boom" not in response.text
     assert len(captured) == 1
     assert isinstance(captured[0], RuntimeError)
+    assert calls == []
+
+
+def test_body_not_object_is_invalid_input(server_client):
+    client, calls = server_client
+
+    response = client.post(
+        "/chart",
+        content=b"[1, 2, 3]",
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 400
+    payload = response.json()
+    assert payload["ok"] is False
+    assert payload["error"] == "invalid_input"
+    assert payload["field"] is None
+    assert payload["detail"] == "body must be a JSON object"
+    assert set(payload) == {"ok", "error", "field", "detail"}
     assert calls == []

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -148,7 +148,19 @@ def test_api_key_rejects_missing_or_wrong_header(server_client, monkeypatch):
     wrong = client.post("/chart", json=BODY, headers={"X-Engine-Key": "bad"})
 
     assert missing.status_code == 401
+    assert missing.json() == {
+        "ok": False,
+        "error": "unauthorized",
+        "field": None,
+        "detail": "missing or incorrect X-Engine-Key",
+    }
     assert wrong.status_code == 401
+    assert wrong.json() == {
+        "ok": False,
+        "error": "unauthorized",
+        "field": None,
+        "detail": "missing or incorrect X-Engine-Key",
+    }
     assert calls == []
 
 
@@ -172,6 +184,11 @@ def test_fail_closed_when_no_key_configured(server_client, monkeypatch):
     response = client.post("/chart", json=BODY)
 
     assert response.status_code == 503
+    assert response.json() == {
+        "ok": False,
+        "error": "not_configured",
+        "message": "ENGINE_API_KEY not configured",
+    }
     assert calls == []
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -470,3 +470,37 @@ def test_polar_coordinates_return_422(server_client, monkeypatch):
     assert "placidus" not in payload["message"]
     assert set(payload) == {"ok", "error", "message"}
     assert calls == []
+
+
+def test_internal_error_does_not_leak_exception_message(server_client, monkeypatch):
+    client, calls = server_client
+    import server as server_mod
+    import sentry_config
+
+    captured = []
+
+    def fake_capture(exc):
+        captured.append(exc)
+
+    monkeypatch.setattr(sentry_config, "capture_exception", fake_capture)
+    monkeypatch.setattr(server_mod, "capture_exception", fake_capture)
+
+    def raise_sensitive(_inp):
+        raise RuntimeError("/app/node_modules boom")
+
+    monkeypatch.setattr(server_mod, "build_json", raise_sensitive)
+
+    response = client.post("/chart", json=BODY)
+
+    assert response.status_code == 500
+    payload = response.json()
+    assert payload == {
+        "ok": False,
+        "error": "internal_error",
+        "message": "chart computation failed",
+    }
+    assert "/app" not in response.text
+    assert "boom" not in response.text
+    assert len(captured) == 1
+    assert isinstance(captured[0], RuntimeError)
+    assert calls == []

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -448,3 +448,25 @@ def test_deeply_nested_body_is_invalid_json(server_client):
     assert payload["error"] == "invalid_json"
     assert payload["field"] is None
     assert calls == []
+
+
+def test_polar_coordinates_return_422(server_client, monkeypatch):
+    client, calls = server_client
+    from scripts.ephemeris import ComputationUnsupportedError
+    import server as server_mod
+
+    def raise_unsupported(_inp):
+        raise ComputationUnsupportedError("placidus undefined at high latitude")
+
+    monkeypatch.setattr(server_mod, "build_json", raise_unsupported)
+
+    response = client.post("/chart", json=BODY)
+
+    assert response.status_code == 422
+    payload = response.json()
+    assert payload["ok"] is False
+    assert payload["error"] == "computation_unsupported"
+    assert payload["message"] == "chart cannot be computed for the given coordinates"
+    assert "placidus" not in payload["message"]
+    assert set(payload) == {"ok", "error", "message"}
+    assert calls == []

--- a/tests/test_synastry_http.py
+++ b/tests/test_synastry_http.py
@@ -734,7 +734,7 @@ def test_surrogate_escaped_configured_key_is_401_not_500(client, monkeypatch):
     assert raw_payload["error"] == "unauthorized"
     assert set(raw_payload) == {"ok", "error", "field", "detail"}
 
-    # /chart shares _auth_failure: it must regain its 401, not raise.
+    # /chart shares _auth_failure: it must return the 401 envelope, not raise.
     chart = http.post(
         "/chart",
         json={
@@ -745,7 +745,12 @@ def test_surrogate_escaped_configured_key_is_401_not_500(client, monkeypatch):
     )
 
     assert chart.status_code == 401, chart.text
-    assert chart.json() == {"detail": "unauthorized"}
+    assert chart.json() == {
+        "ok": False,
+        "error": "unauthorized",
+        "field": None,
+        "detail": "missing or incorrect X-Engine-Key",
+    }
 
 
 def test_wrong_key_is_401_unauthorized(client, monkeypatch):


### PR DESCRIPTION
## 問題

- **F-2**：`/chart` 的 500 分支把 `str(exc)` 原樣回給呼叫端。洩漏向量是 `scripts/chart_engine.py:220-221`——紫微 sidecar 失敗時把 `proc.stderr` 併進 `RuntimeError`，內容含容器絕對路徑與 Node stderr。
- **F-3**：`/chart` 只接 `JSONDecodeError`，非法 UTF-8 body 或深巢狀 JSON 會裸 500；極地座標回 500 而非 422。`/synastry`（E5）早已正確。

## 做法

把 E5 為 `/synastry` 建好的六 token envelope 與固定決策順序（`not_configured → unauthorized → invalid_json → invalid_input → computation_unsupported → internal_error`）原樣套到 `/chart`，重用既有的 `_auth_failure` / `_input_error` / `_message_error`，刪掉因此變成孤兒的 `_require_key` / `_engine_input` 與不再使用的 import。`/chart` 的 `internal_error` 固定訊息是 `"chart computation failed"`。

同步更新 `AGENTS.md` §5：錯誤傳輸矩陣的 `/chart` 欄、契約小節改為同時涵蓋兩個端點、標明兩者差異（internal_error 訊息、body-not-object 的 field）。

## 契約變更與相容性

`/chart` 的錯誤 body 從 FastAPI 的 `{"detail": ...}` 改為六 token envelope，且極地座標從 500 改為 422。

- life-web 只依 status 區間分支（`src/lib/engine/client.ts:79-89`：4xx → `EngineInputError`、5xx/`ok:false` → `EngineRuntimeError`），不讀 body 欄位，故相容。極地座標現在走 `EngineInputError` → `/api/chart` 回 400 `invalid_input`（而非 502 `engine_unavailable`），與 `/synastry` 既有行為一致，也不再產生 Sentry 假警報。
- `tests/test_node_absence.py` 原本斷言 Node 提示會回給 HTTP 呼叫端——那正是 F-2 要堵的洩漏，已改為斷言固定訊息並反向斷言不含 `Node.js` / `sidecar`。操作者提示仍在 CLI（exit 1）、容器 log 與 Sentry。
- CLI 單人模式的 `{"ok": false, "error": "<message>"}` 未改動。

## 驗證

- `pytest tests/` **440 passed / 1 skipped**（main 基準 435/1，本 PR 淨增 5 個測試，無測試被刪或弱化）
- `ruff check .` clean
- 交叉審查：Codex `-r --base main` 🟢 no findings；DeepSeek（deepseek-v4-pro）獨立審查逐項 🟢，唯一 🟡 是 AGENTS.md 表格 field 欄位歧義，已於 8dc936e 修掉

## TDD

每個 behavior 一個 `test+impl:` commit（invalid_json / computation_unsupported / internal_error / invalid_input / auth），先紅後綠。