### PR TITLE
fix(server): request body 上限 413（LIFE_MAX_BODY_BYTES，預設 64 KiB）；API key 比對補同長度／空值測試；反代限流寫入 runbook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -429,6 +429,15 @@ computed normally.
   `422 computation_unsupported`, `503 not_configured`.
 - **Retryable**: `500 internal_error`, plus upstream proxy 5xx and timeouts.
 
+**Request body size cap (pre-auth, pre-parse):** `POST /chart` and
+`POST /synastry` reject a request body over `LIFE_MAX_BODY_BYTES` (default
+`65536`, i.e. 64 KiB) with `413` before the six-token decision order above
+even starts — it runs ahead of `X-Engine-Key` verification and JSON parsing,
+at the ASGI transport layer. Body: `{"ok": false, "error": "body_too_large",
+"message": "request body exceeds the configured size limit"}`. Not one of
+the six tokens (it is not part of the `/chart` vs `/synastry` per-body
+contract above) and not retryable with the same body.
+
 ---
 
 ## 6. MCP surface (`compute_chart`)

--- a/DEPLOY-HETZNER.md
+++ b/DEPLOY-HETZNER.md
@@ -210,3 +210,56 @@ PY
 with the deploy evidence. As a final outside check,
 `curl https://engine-life.aicycle.cc/health` must return JSON containing
 `"schema_version": "1.2"`.
+
+## 7. Per-IP rate limiting (NOT applied yet — ops task on the host)
+
+`ENGINE_API_KEY` and the `LIFE_MAX_BODY_BYTES` request-size cap (server.py,
+default 64 KiB) are the only request-shedding controls the Python service
+implements. Per-IP request-rate limiting is deliberately **not** implemented
+in Python — it belongs at the reverse-proxy/edge layer in front of the
+container, where it can reject abusive traffic before it reaches the process.
+**This has not been configured on the reference Hetzner host as of this
+writing.**
+
+The reference deployment fronts the container with a Cloudflare Tunnel
+(`cloudflared`, see §3), not a locally-run Caddy/nginx. Cloudflare's own edge
+(WAF rate limiting rules on the zone) is the natural place to add this for
+that specific topology. If a local reverse proxy sits in front of the
+container instead (or is added later), concrete config to adapt:
+
+**Caddy** (`rate_limit` via the `caddy-ratelimit` plugin — not built into
+core Caddy, must be added at build time):
+
+```
+engine-life.aicycle.cc {
+	rate_limit {
+		zone engine_per_ip {
+			key {remote_host}
+			events 60
+			window 1m
+		}
+	}
+	reverse_proxy 127.0.0.1:8012
+}
+```
+
+**nginx** (`limit_req`, built in):
+
+```nginx
+limit_req_zone $binary_remote_addr zone=engine_per_ip:10m rate=60r/m;
+
+server {
+    listen 443 ssl;
+    server_name engine-life.aicycle.cc;
+
+    location / {
+        limit_req zone=engine_per_ip burst=20 nodelay;
+        proxy_pass http://127.0.0.1:8012;
+    }
+}
+```
+
+Either snippet caps at ~60 requests/minute/IP as a starting point — tune to
+the actual `life-web` call volume before relying on it. Whichever layer is
+chosen, verify it actually rejects with a `429` under load before treating
+this section as done; an unapplied snippet in a doc is not a mitigation.

--- a/server.py
+++ b/server.py
@@ -1,4 +1,5 @@
 import hmac
+import json
 import os
 from typing import Any
 
@@ -18,9 +19,93 @@ from scripts.validation import validate_input
 from sentry_config import capture_exception, init_sentry
 
 
+DEFAULT_MAX_BODY_BYTES = 64 * 1024  # 64 KiB
+MESSAGE_BODY_TOO_LARGE = "request body exceeds the configured size limit"
+
+
+def _max_body_bytes() -> int:
+    # Read per-request (not cached at import time) so LIFE_MAX_BODY_BYTES can
+    # be overridden via monkeypatch/env without re-importing the module -- the
+    # same pattern ENGINE_API_KEY already uses in ``_auth_failure``.
+    raw = os.environ.get("LIFE_MAX_BODY_BYTES")
+    if raw is None:
+        return DEFAULT_MAX_BODY_BYTES
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_MAX_BODY_BYTES
+    return value if value > 0 else DEFAULT_MAX_BODY_BYTES
+
+
+class _BodyTooLarge(Exception):
+    pass
+
+
+class BodySizeLimitMiddleware:
+    """Reject oversized request bodies with 413 before any JSON parsing.
+
+    Pure-ASGI (not Starlette's ``BaseHTTPMiddleware``, which buffers the
+    whole body) so an attacker cannot force full buffering of an unbounded
+    stream: a declared ``Content-Length`` over the cap is rejected without
+    reading the body at all, and a body lacking (or lying about) that header
+    is rejected as soon as the streamed bytes cross the cap.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        max_bytes = _max_body_bytes()
+        headers = dict(scope.get("headers") or [])
+        content_length = headers.get(b"content-length")
+        if content_length is not None:
+            try:
+                declared = int(content_length)
+            except ValueError:
+                declared = None
+            if declared is not None and declared > max_bytes:
+                await _send_413(send, max_bytes)
+                return
+
+        seen = 0
+
+        async def limited_receive():
+            nonlocal seen
+            message = await receive()
+            if message["type"] == "http.request":
+                seen += len(message.get("body") or b"")
+                if seen > max_bytes:
+                    raise _BodyTooLarge()
+            return message
+
+        try:
+            await self.app(scope, limited_receive, send)
+        except _BodyTooLarge:
+            await _send_413(send, max_bytes)
+
+
+async def _send_413(send, max_bytes: int) -> None:
+    body = json.dumps(
+        {"ok": False, "error": "body_too_large", "message": MESSAGE_BODY_TOO_LARGE}
+    ).encode("utf-8")
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 413,
+            "headers": [(b"content-type", b"application/json")],
+        }
+    )
+    await send({"type": "http.response.body", "body": body})
+
+
 init_sentry()
 
 app = FastAPI(title="life-chart-engine")
+app.add_middleware(BodySizeLimitMiddleware)
 
 MESSAGE_NOT_CONFIGURED = "ENGINE_API_KEY not configured"
 MESSAGE_CHART_INTERNAL = "chart computation failed"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -562,3 +562,86 @@ def test_body_not_object_is_invalid_input(server_client):
     assert payload["detail"] == "body must be a JSON object"
     assert set(payload) == {"ok", "error", "field", "detail"}
     assert calls == []
+
+
+def test_api_key_rejects_wrong_key_same_length(server_client, monkeypatch):
+    # Same-length mismatch specifically exercises the hmac.compare_digest
+    # code path rather than a length short-circuit.
+    client, calls = server_client
+    monkeypatch.setenv("ENGINE_API_KEY", "secret")
+
+    response = client.post("/chart", json=BODY, headers={"X-Engine-Key": "wrongo"})
+
+    assert response.status_code == 401
+    assert response.json()["error"] == "unauthorized"
+    assert calls == []
+
+
+def test_api_key_rejects_empty_header(server_client, monkeypatch):
+    client, calls = server_client
+    monkeypatch.setenv("ENGINE_API_KEY", "secret")
+
+    response = client.post("/chart", json=BODY, headers={"X-Engine-Key": ""})
+
+    assert response.status_code == 401
+    assert response.json()["error"] == "unauthorized"
+    assert calls == []
+
+
+def test_oversized_body_returns_413(server_client, monkeypatch):
+    client, calls = server_client
+    monkeypatch.setenv("LIFE_MAX_BODY_BYTES", "100")
+
+    response = client.post(
+        "/chart",
+        content=b"x" * 200,
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 413
+    payload = response.json()
+    assert payload == {
+        "ok": False,
+        "error": "body_too_large",
+        "message": "request body exceeds the configured size limit",
+    }
+    assert calls == []
+
+
+def test_body_under_cap_is_processed_normally(server_client, monkeypatch):
+    client, calls = server_client
+    monkeypatch.setenv("LIFE_MAX_BODY_BYTES", "100")
+
+    response = client.post("/chart", json=BODY)
+
+    assert response.status_code == 200
+    assert len(calls) == 1
+
+
+def test_oversized_synastry_body_returns_413(server_client, monkeypatch):
+    client, calls = server_client
+    monkeypatch.setenv("LIFE_MAX_BODY_BYTES", "100")
+
+    response = client.post(
+        "/synastry",
+        content=b"x" * 200,
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 413
+    payload = response.json()
+    assert payload["ok"] is False
+    assert payload["error"] == "body_too_large"
+    assert calls == []
+
+
+def test_default_body_cap_allows_ordinary_chart_request(server_client, monkeypatch):
+    # No LIFE_MAX_BODY_BYTES override: the 64 KiB default must not reject a
+    # normal, unremarkable /chart payload.
+    monkeypatch.delenv("LIFE_MAX_BODY_BYTES", raising=False)
+    client, calls = server_client
+
+    response = client.post("/chart", json=BODY)
+
+    assert response.status_code == 200
+    assert len(calls) == 1


### PR DESCRIPTION
life-web `docs/2026-08-28-business-logic-audit.md:210-211,:30` 三項：(a) API key 比對——現行 `_auth_failure` 已是 `hmac.compare_digest`（稽核針對舊 commit），補同長度錯 key／空 header 兩個測試；(b) 新增純 ASGI `BodySizeLimitMiddleware`，超過 `LIFE_MAX_BODY_BYTES`（預設 65536）在 auth 與 JSON 解析前回 413 `{ok:false,error:body_too_large}`，Content-Length 與串流計數雙路徑；(c) per-IP 限流屬主機／Cloudflare 層，`DEPLOY-HETZNER.md` §7 給 Caddy/nginx 片段並明示尚未套用。AGENTS.md 記 413 為 pre-auth 閘門（additive）。test_server 43 綠、ruff 全過、`tests/test_json_output.py` ok；全套件 441 passed。

https://claude.ai/code/session_015N1EWpaPKxnFQxzxP1Jvca